### PR TITLE
Support Egeria 4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,61 +6,51 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
+---
 name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-*, feature-*]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main]
-  schedule:
-    - cron: '0 20 * * 0'
+    branches: [main, release-*, feature-*]
+  workflow_dispatch:
 
 jobs:
   analyze:
-    name: Analyze
+    if: startsWith(github.repository,'odpi/')
+    name: "CodeQL"
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['java']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+          languages: java
           queries: security-and-quality
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      # - run: |
-      #    make bootstrap
-      #    make release
-
+          ram: 4096
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          # codeQL requires a full before/after build to compare results. Caching can result in action failing
+          #cache-read-only: true
+          cache-disabled: true
+          arguments: -x javadoc -x test build
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        with:
+          ram: 4096

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - uses: gradle/wrapper-validation-action@v1
       # Only for a merge into this repo - not a fork, and just for the main branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - uses: gradle/wrapper-validation-action@v1
       - name: Build with Gradle & Release artifacts
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - uses: gradle/wrapper-validation-action@v1
       - name: Build

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     // Checks for unnecessary dependencies
     id 'com.autonomousapps.dependency-analysis' version "1.19.0"
     // helps resolve log implementation clashes
-    id 'dev.jacomet.logging-capabilities' version "0.10.0"
+    id 'dev.jacomet.logging-capabilities' version "0.11.0"
     // This plugin helps resolve jakarta/javax dev.jacomet.logging-capabilities
     id 'org.gradlex.java-ecosystem-capabilities' version "1.1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,15 @@
  * Plugins for this parent module only - so just high level project related
  */
 plugins {
-    id "io.freefair.aggregate-javadoc" version "6.6.3"
-    // Checks for unnecessary dependencies
+    id 'java-library'
+    id "com.github.johnrengelman.shadow" version "8.1.0"
+    id 'idea'
+    id 'maven-publish'
+    // Checks for unnecessary & problematic dependencies
     id 'com.autonomousapps.dependency-analysis' version "1.19.0"
     // helps resolve log implementation clashes
     id 'dev.jacomet.logging-capabilities' version "0.11.0"
-    // This plugin helps resolve jakarta/javax dev.jacomet.logging-capabilities
+    // This plugin helps resolve jakarta/javax clashes
     id 'org.gradlex.java-ecosystem-capabilities' version "1.1"
 }
 
@@ -25,7 +28,7 @@ plugins {
 allprojects {
 
     group = 'org.odpi.egeria'
-    version = '1.0'
+    version = '1.1-SNAPSHOT'
 
     // Mostly java, so default to this for now
     apply plugin: 'java'
@@ -39,7 +42,7 @@ allprojects {
     repositories {
         mavenCentral()
         // only needed if building against egeria snapshot versions
-        //maven { url("https://oss.sonatype.org/content/repositories/snapshots") }
+        maven { url("https://oss.sonatype.org/content/repositories/snapshots") }
     }
 
     // ensures we pick up the very latest snapshots when built
@@ -55,7 +58,7 @@ allprojects {
     // Assign variables for any constraints
     ext {
         // add version variables here
-        egeriaversion='3.15'
+        egeriaversion='4.0-SNAPSHOT'
     }
 
     dependencies {
@@ -74,7 +77,7 @@ allprojects {
         withJavadocJar()
     }
     tasks.withType(JavaCompile) {
-        options.release = 11
+        options.release = 17
         options.encoding = 'UTF-8'
         options.incremental = true
         options.failOnError = true
@@ -96,15 +99,9 @@ allprojects {
         useJUnitPlatform {
             includeEngines 'junit-jupiter'
         }
-        dependencies {
-            testImplementation 'org.junit.jupiter:junit-jupiter-api'
-            testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-        }
-
         testLogging {
             events "passed", "skipped", "failed"
         }
-
         reports {
             html.required = true
         }
@@ -243,9 +240,6 @@ dependencyAnalysis {
         all {
             onAny {
                 severity('fail')
-            }
-            onUnusedDependencies {
-                exclude("junit:junit", "org.junit.jupiter:junit-jupiter-api", "org.junit.jupiter:junit-jupiter-engine", "com.fasterxml.jackson.core:jackson-annotations")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@
 plugins {
     id "io.freefair.aggregate-javadoc" version "6.6.3"
     // Checks for unnecessary dependencies
-    id 'com.autonomousapps.dependency-analysis' version "1.18.0"
+    id 'com.autonomousapps.dependency-analysis' version "1.19.0"
     // helps resolve log implementation clashes
     id 'dev.jacomet.logging-capabilities' version "0.10.0"
     // This plugin helps resolve jakarta/javax dev.jacomet.logging-capabilities

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@
  * Plugins for this parent module only - so just high level project related
  */
 plugins {
-    id "io.freefair.aggregate-javadoc" version "6.6.1"
+    id "io.freefair.aggregate-javadoc" version "6.6.3"
     // Checks for unnecessary dependencies
     id 'com.autonomousapps.dependency-analysis' version "1.18.0"
     // helps resolve log implementation clashes

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jdbc-integration-connector/build.gradle
+++ b/jdbc-integration-connector/build.gradle
@@ -14,6 +14,12 @@ dependencies {
     compileOnly 'org.odpi.egeria:data-manager-api'
     compileOnly 'org.odpi.egeria:database-integrator-api'
     compileOnly 'org.odpi.egeria:open-connector-framework'
+    compileOnly 'org.odpi.egeria:audit-log-framework'
+    compileOnly 'org.odpi.egeria:repository-services-apis'
+    compileOnly 'org.odpi.egeria:open-integration-framework'
+    compileOnly 'org.apache.commons:commons-lang3'
+    compileOnly 'org.apache.commons:commons-collections4'
     implementation project(':egeria-connector-resource-jdbc')
+    compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }
 

--- a/jdbc-resource-connector/build.gradle
+++ b/jdbc-resource-connector/build.gradle
@@ -11,5 +11,6 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     compileOnly 'org.odpi.egeria:open-connector-framework'
     compileOnly 'org.odpi.egeria:audit-log-framework'
+    compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }
 


### PR DESCRIPTION
* cherry picks outstanding dependabot updates
* Updates to depend on egeria 4
* updates gradle to current version
* updates plugins etc
* Adds missing dependencies

Note: 
 a) Not yet tested. To ensure the build process is workable as a starting point for further work, I will merge this change
as a good starting point for doing that validation
 b) This is not yet released, just building 1.1-SNAPSHOT